### PR TITLE
switched to using new metadata['display_name'] for user keys in redis…

### DIFF
--- a/legos/markov.py
+++ b/legos/markov.py
@@ -20,7 +20,7 @@ class MarkovListener(Lego):
     def handle(self, message):
         # Exclude bot commands from model input
         if not message['text'].startswith("!"):
-            self.append_text(message['metadata']['source_username'],
+            self.append_text(message['metadata']['display_name'],
                              message['text'])
 
     def append_text(self, user, text):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-legobot>=1.1.4,<=2.0.0
+legobot>=1.2.1,<=2.0.0
 nltk
 markovify
 bandit==1.3.0


### PR DESCRIPTION
… db. subsequently changed requirements to legobot 1.2.1 or greater.